### PR TITLE
Remove deprecated frameborder attribute. Fixes #2.

### DIFF
--- a/css/video_filter.css
+++ b/css/video_filter.css
@@ -13,3 +13,7 @@
   display: block;
   margin: 0 auto;
 }
+
+.video-filter {
+  border: none;
+}

--- a/video_filter.module
+++ b/video_filter.module
@@ -323,7 +323,8 @@ function theme_video_filter_iframe($variables) {
     $attributes = backdrop_attributes($video['attributes']);
   }
 
-  $output = '<iframe src="' . $video['source'] . '" width="' . $video['width'] . '" height="' . $video['height'] . '" class="' . implode(' ', $classes) . '" frameborder="0"' . $attributes . '></iframe>';
+  $output = '<iframe src="' . $video['source'] . '" width="' . $video['width'] . '" height="' . $video['height'] . '" class="' . implode(' ', $classes) . '" ' . $attributes . '></iframe>';
+
 
   return $output;
 }


### PR DESCRIPTION
The iframe attribute frameborder is not supported in HTML5, so we should use CSS instead.